### PR TITLE
填坑

### DIFF
--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -17,6 +17,7 @@ module CarrierWave
           @qiniu_protocol      = options[:qiniu_protocol] || "http"
           @qiniu_async_ops     = options[:qiniu_async_ops] || ''
           @qiniu_can_overwrite = options[:qiniu_can_overwrite] || false
+          @qiniu_expires_in    = options[:expires_in] || 3600
           init
         end
 
@@ -27,7 +28,7 @@ module CarrierWave
           put_policy = ::Qiniu::Auth::PutPolicy.new(
             @qiniu_bucket,
             key,
-            2,
+            @qiniu_expires_in,
             1
           )
 


### PR DESCRIPTION
新增上传凭证的有效期设定，在上传头像和照片时，根据文件大小限定可以设置延长或即时更新。

过期时间太短会造成：401 Unauthorized => Qiniu::HTTP.post('http://up.qiniu.com/') 错误。

之前修改这个值，是我挖的坑，对不住大伙了~  :crying_cat_face: 
