### PR TITLE
added config qiniu_private_url_expires_in

### DIFF
--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -134,6 +134,7 @@ module CarrierWave
               :qiniu_protocol      => @uploader.qiniu_protocol,
               :qiniu_expires_in    => @uploader.qiniu_expires_in,
               :qiniu_up_host       => @uploader.qiniu_up_host
+              :qiniu_private_url_expires_in => @uploader.qiniu_private_url_expires_in
             }
 
             if @uploader.respond_to?(:qiniu_async_ops) and !@uploader.qiniu_async_ops.nil? and @uploader.qiniu_async_ops.size > 0


### PR DESCRIPTION
BUG FIX. 没有在初始化的时候设置private_url_expires_in，而导致缺省被使用。