### PR TITLE
Private url expires in

### DIFF
--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -133,7 +133,7 @@ module CarrierWave
               :qiniu_block_size    => @uploader.qiniu_block_size,
               :qiniu_protocol      => @uploader.qiniu_protocol,
               :qiniu_expires_in    => @uploader.qiniu_expires_in,
-              :qiniu_up_host       => @uploader.qiniu_up_host
+              :qiniu_up_host       => @uploader.qiniu_up_host,
               :qiniu_private_url_expires_in => @uploader.qiniu_private_url_expires_in
             }
 

--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -134,6 +134,7 @@ module CarrierWave
               :qiniu_protocol      => @uploader.qiniu_protocol,
               :qiniu_expires_in    => @uploader.qiniu_expires_in,
               :qiniu_up_host       => @uploader.qiniu_up_host
+              :qiniu_private_url_expires_in => @uploader.qiniu_private_url_expires_in
             }
 
             if @uploader.respond_to?(:qiniu_async_ops) and !@uploader.qiniu_async_ops.nil? and @uploader.qiniu_async_ops.size > 0


### PR DESCRIPTION
没有设置 qiniu_private_url_expires_in 参数，导致过期还是使用默认3600.