### PR TITLE
增加对七牛SDK中复制图片功能的支持

### DIFF
--- a/lib/carrierwave-qiniu.rb
+++ b/lib/carrierwave-qiniu.rb
@@ -2,6 +2,7 @@
 require "carrierwave-qiniu/version"
 require "carrierwave/storage/qiniu"
 require "carrierwave/qiniu/configuration"
+require "carrierwave/uploader/base"
 
 ::CarrierWave.configure do |config|
   config.storage_engines[:qiniu] = "::CarrierWave::Storage::Qiniu".freeze

--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -200,7 +200,11 @@ module CarrierWave
 
       def store!(file)
         f = ::CarrierWave::Storage::Qiniu::File.new(uploader, uploader.store_path(uploader.filename))
-        f.store(file)
+        if file && file.copy_from_path
+          f.copy_from file.copy_from_path
+        else
+          f.store(file)
+        end
         f
       end
 

--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -50,6 +50,17 @@ module CarrierWave
 
         end
 
+        #
+        # @note 复制
+        # @param origin [String]
+        # @param target [String]
+        # @return [Boolean]
+        #
+        def copy(origin, target)
+          code, result, _ = ::Qiniu::Storage.copy(@qiniu_bucket, origin, @qiniu_bucket, target)
+          code == 200 ? result : nil
+        end
+
         def delete(key)
           ::Qiniu::Storage.delete(@qiniu_bucket, key) rescue nil
         end
@@ -117,6 +128,22 @@ module CarrierWave
 
         def delete
           qiniu_connection.delete(@path)
+        end
+
+
+
+        #
+        # @note 从指定路径复制图片
+        # @param origin_path [String] 原图片路径
+        # @return [Boolean]
+        #
+        def copy_from(origin_path)
+
+          # 先删除目标图片，避免出现0字节文件，无法复制
+          qiniu_connection.delete(@path)
+
+          qiniu_connection.copy(origin_path, @path)
+
         end
 
         ##

--- a/lib/carrierwave/uploader/base.rb
+++ b/lib/carrierwave/uploader/base.rb
@@ -1,0 +1,35 @@
+#encoding: utf-8
+module CarrierWave
+
+  class SanitizedFile
+
+    attr_accessor :copy_from_path
+
+  end
+
+  module Uploader
+    module Cache
+
+      alias_method :old_cache!, :cache!
+
+      def cache!(new_file = sanitized_file)
+
+        old_cache! new_file
+
+        if new_file.kind_of? CarrierWave::Storage::Qiniu::File
+
+          @file.copy_from_path = new_file.path
+
+        elsif new_file.kind_of? CarrierWave::Uploader::Base
+
+          @file.copy_from_path = new_file.file.path
+
+        end
+
+      end
+    end
+
+  end
+
+
+end

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -93,5 +93,25 @@ require 'carrierwave/processing/mini_magick'
       open(photo.image.thumb.url).should_not be_nil
 
     end
+
+    it 'does copy from image works' do
+      f = load_file("mm.jpg")
+
+      photo = Photo.new(image: f)
+
+      photo.save
+
+      photo2 = Photo.new
+
+      photo2.image = photo.image
+
+      photo2.save
+
+      puts "The image was copied from #{photo.image.url} to #{photo2.image.url}"
+
+      expect(photo2.image.url).not_to eq(photo.image.url)
+
+      open(photo2.image.url).should_not be_nil
+    end
   end
 end


### PR DESCRIPTION
在两个uploader直接赋值的时候，使用七牛的 复制图片功能，直接将原图复制到目标路径上。