### PR TITLE
提供图片样式的便利方法

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,44 @@ class AvatarUploader < CarrierWave::Uploader::Base
 
 end
 ```
+
+You can use [qiniu image styles](https://qiniu.kf5.com/hc/kb/article/68884/) instead [version](https://github.com/carrierwaveuploader/carrierwave#adding-versions) processing of CarrierWave.
+```
+# Case 1
+class AvatarUploader < CarrierWave::Uploader::Base
+  storage :qiniu
+
+  qiniu_styles [:thumb, :large]
+end
+
+# original url
+user.avatar.url
+
+# thumb url
+user.avatar.url(:thumb)
+# http://.../avatar.jpg-thumb
+
+
+# Case 2
+class AvatarUploader < CarrierWave::Uploader::Base
+  storage :qiniu
+
+  qiniu_styles thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800'
+end
+
+# thumb url
+user.avatar.url(:thumb)
+# http://.../avatar.jpg-thumb
+
+# inline thubm url
+user.avatar.url(:thumb, inline: true)
+# http://.../avatar.jpg?imageView2/1/w/200
+
+# just style param
+user.avatar.url(style: 'imageView2/1/w/200')
+# http://.../avatar.jpg?imageView2/1/w/200
+```
+
 You can see a example project on: https://github.com/huobazi/carrierwave-qiniu-example
 
 or see the spec test on https://github.com/huobazi/carrierwave-qiniu/blob/master/spec/upload_spec.rb

--- a/lib/carrierwave-qiniu.rb
+++ b/lib/carrierwave-qiniu.rb
@@ -2,6 +2,7 @@
 require "carrierwave-qiniu/version"
 require "carrierwave/storage/qiniu"
 require "carrierwave/qiniu/configuration"
+require "carrierwave/qiniu/style"
 require "carrierwave/uploader/base"
 
 ::CarrierWave.configure do |config|
@@ -9,3 +10,4 @@ require "carrierwave/uploader/base"
 end
 
 ::CarrierWave::Uploader::Base.send(:include, ::CarrierWave::Qiniu::Configuration)
+::CarrierWave::Uploader::Base.send(:include, ::CarrierWave::Qiniu::Style)

--- a/lib/carrierwave/qiniu/configuration.rb
+++ b/lib/carrierwave/qiniu/configuration.rb
@@ -20,11 +20,30 @@ module CarrierWave
         add_config :qiniu_expires_in
         add_config :qiniu_up_host
         add_config :qiniu_private_url_expires_in
+        add_config :qiniu_style_separator
 
         alias_config :qiniu_protocal, :qiniu_protocol
+
+        reset_qiniu_config
       end
 
       module ClassMethods
+        # Set default value
+        def reset_qiniu_config
+          configure do |config|
+            config.qiniu_protocol = 'http'
+            config.qiniu_bucket_private = false
+            config.qiniu_block_size = 1024*1024*4
+            config.qiniu_async_ops = ''
+            config.qiniu_can_overwrite = false
+            config.qiniu_private_url_expires_in = 3600
+            config.qiniu_callback_url = ''
+            config.qiniu_callback_body = ''
+            config.qiniu_persistent_notify_url = ''
+            config.qiniu_style_separator = '-'
+          end
+        end
+
         def alias_config(new_name, old_name)
           class_eval <<-RUBY, __FILE__, __LINE__ + 1
           def self.#{new_name}(value=nil)

--- a/lib/carrierwave/qiniu/style.rb
+++ b/lib/carrierwave/qiniu/style.rb
@@ -1,0 +1,35 @@
+require 'carrierwave/qiniu/url'
+
+module CarrierWave
+  module Qiniu
+    module Style
+      extend ActiveSupport::Concern
+
+      class_methods do
+        # === Examples:
+        #
+        #    qiniu_styles [:thumbnail, :large]
+        #    qiniu_styles :thumbnail => 'imageView/0/w/200', :large => 'imageView/0/w/800'
+        #    qiniu_styles
+        #
+        def qiniu_styles(versions = nil)
+          # Override #url method when set styles, otherwise still default strategy.
+          unless include? ::CarrierWave::Qiniu::Url
+            send(:include, ::CarrierWave::Qiniu::Url)
+          end
+
+          @qiniu_styles = {}
+          if versions.is_a? Array
+            @qiniu_styles = versions.map { |version| [version.to_sym, nil] }.to_h
+          elsif versions.is_a? Hash
+            @qiniu_styles = versions.symbolize_keys
+          end
+        end
+
+        def get_qiniu_styles
+          @qiniu_styles
+        end
+      end
+    end
+  end
+end

--- a/lib/carrierwave/qiniu/url.rb
+++ b/lib/carrierwave/qiniu/url.rb
@@ -1,0 +1,45 @@
+module CarrierWave
+  module Qiniu
+    module Url
+      # === Examples:
+      #
+      #     avatar.url(:version)
+      #     avatar.url(:version, inline: true)
+      #     avatar.url(style: 'imageView2/0/w/200')
+      #
+      def url(*args)
+        return super if args.empty?
+
+        if args.first.is_a? Hash
+          options = args.first
+          # Usage: avatar.url(style: 'imageView/0/w/200')
+          if options[:style]
+            url = super({})
+            return "#{url}?#{options[:style]}"
+          end
+        else
+          version = args.first.to_sym
+          if qiniu_styles.key? version.to_sym
+            options = args.last
+
+            # TODO: handle private url
+            url = super({})
+            # Usage: avatar.url(:version, inline: true)
+            if options.present? && options.is_a?(Hash) && options[:inline] && qiniu_styles[version]
+              return "#{url}?#{qiniu_styles[version]}"
+            else # Usage: avatar.url(:version)
+              return "#{url}#{self.class.qiniu_style_separator}#{version}"
+            end
+          end
+        end
+
+        # Fallback to original url
+        super
+      end
+
+      def qiniu_styles
+        self.class.get_qiniu_styles
+      end
+    end
+  end
+end

--- a/lib/carrierwave/storage/qiniu.rb
+++ b/lib/carrierwave/storage/qiniu.rb
@@ -24,6 +24,7 @@ module CarrierWave
           @qiniu_callback_url           = options[:qiniu_callback_url] || ''
           @qiniu_callback_body          = options[:qiniu_callback_body] || ''
           @qiniu_persistent_notify_url  = options[:qiniu_persistent_notify_url] || ''
+          @qiniu_style_separator        = options[:qiniu_style_separator] || '-'
           init
         end
 
@@ -197,7 +198,8 @@ module CarrierWave
               :qiniu_private_url_expires_in => @uploader.qiniu_private_url_expires_in,
               :qiniu_callback_url  => @uploader.qiniu_callback_url,
               :qiniu_callback_body => @uploader.qiniu_callback_body,
-              :qiniu_persistent_notify_url  => @uploader.qiniu_persistent_notify_url
+              :qiniu_persistent_notify_url  => @uploader.qiniu_persistent_notify_url,
+              :qiniu_style_separator => @uploader.qiniu_style_separator
             }
 
             config[:qiniu_async_ops] = Array(@uploader.qiniu_async_ops).join(';') rescue ''

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,9 +47,6 @@ end
 
   config.qiniu_bucket        = ENV['qiniu_bucket']
   config.qiniu_bucket_domain = ENV['qiniu_bucket_domain']
-
-  config.qiniu_block_size    = 4*1024*1024
-  config.qiniu_protocol      = "http"
 end
 
 def load_file(fname)
@@ -60,4 +57,3 @@ end
 RSpec.configure do |config|
 
 end
-

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -77,12 +77,15 @@ require 'carrierwave/processing/mini_magick'
         self.qiniu_bucket = 'not_exists'
       end
 
-      class Photo < ActiveRecord::Base
+      class WrongPhoto < ActiveRecord::Base
+        self.table_name = 'photos'
+
         mount_uploader :image, WrongUploader
       end
 
       f = load_file("mm.jpg")
-      photo = Photo.new(:image => f)
+      photo = WrongPhoto.new(:image => f)
+      # FIXME: also raise error, see: CarrierWave::Qiniu#store L54
       photo.save
       expect(photo).to_not be_valid
 
@@ -149,5 +152,91 @@ require 'carrierwave/processing/mini_magick'
 
       expect(photo.image.file.exists?).to eq(false)
     end
+  end
+
+  context "Styles" do
+
+    context 'array styles' do
+      class ArrayStylesUploader < CarrierWave::Uploader::Base
+        qiniu_styles [:thumb]
+
+        def store_dir
+          "carrierwave-qiniu-spec"
+        end
+      end
+
+      class ArrayStyledPhoto < ActiveRecord::Base
+        self.table_name = 'photos'
+
+        mount_uploader :image, ArrayStylesUploader
+      end
+
+      it 'style url' do
+        f = load_file("mm.jpg")
+        photo = ArrayStyledPhoto.new(image: f)
+        photo.save
+        photo.errors.count.should == 0
+
+        expect(photo.image.url).not_to be_nil
+        puts photo.image.url('thumb')
+        expect(photo.image.url('thumb').end_with?("mm.jpg-thumb")).to eq true
+      end
+    end
+
+    context "Hash styles" do
+      class HashStylesUploader < CarrierWave::Uploader::Base
+        qiniu_styles thumb: "imageView2/0/w/200"
+
+        def store_dir
+          "carrierwave-qiniu-spec"
+        end
+      end
+
+      class HashStyledPhoto < ActiveRecord::Base
+        self.table_name = 'photos'
+
+        mount_uploader :image, HashStylesUploader
+      end
+
+      it 'style url' do
+        f = load_file("mm.jpg")
+        photo = HashStyledPhoto.new(image: f)
+        photo.save
+        photo.errors.count.should == 0
+
+        expect(photo.image.url).not_to be_nil
+        puts photo.image.url('thumb')
+        expect(photo.image.url('thumb').end_with?("mm.jpg-thumb")).to eq true
+      end
+
+      it 'inline style url' do
+        f = load_file("mm.jpg")
+        photo = HashStyledPhoto.new(image: f)
+        photo.save
+        puts photo.image.url('thumb', inline: true)
+        expect(photo.image.url('thumb', inline: true).end_with?("mm.jpg?imageView2/0/w/200")).to eq true
+      end
+    end
+
+    context "Only Style param" do
+      class StylesUploader < CarrierWave::Uploader::Base
+        qiniu_styles
+      end
+
+      class StyledPhoto < ActiveRecord::Base
+        self.table_name = 'photos'
+
+        mount_uploader :image, StylesUploader
+      end
+
+      it 'url' do
+        f = load_file("mm.jpg")
+        photo = StyledPhoto.new(image: f)
+        photo.save
+        puts photo.image.url(style: 'imageView2/0/w/200')
+        expect(photo.image.url(style: 'imageView2/0/w/200').end_with?("mm.jpg?imageView2/0/w/200")).to eq true
+      end
+    end
+
   end
 end


### PR DESCRIPTION
More to see #67 

Usage:
```
class AvatarUploader < CarrierWave::Uploader::Base
  # 第一种 通过 array 配置图片样式
  qiniu_styles [:thumbnail, :large]
end

# 图片链接
user.avatar.url(:thumbnail)
# "http://..../avatar.jpg-thumbnail"

class AvatarUploader < CarrierWave::Uploader::Base
  # 第二种 通过 hash 配置图片样式
  qiniu_styles { thumbnail: "imageView2/0/w/200", large: "imageView2/0/w/800" }
end

user.avatar.url(:thumbnail)
# "http://..../avatar.jpg-thumbnail"
# 借助于qiniu可以直接在图片链接后面应用图片处理，这样图片样式可以不必事先添加就可以使用，尤其是在开发过程中比较方便
user.avatar.url(:thumbnail, inline: true) 
# "http://..../avatar.jpg?imageView2/0/w/200"


# 第三种 直接使用图片处理
user.avatar.url(style: "imageView2/0/w/200") 
# "http://..../avatar.jpg?imageView2/0/w/200"
```