### PR TITLE
重构了图片样式

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,11 +81,15 @@ end
 
 You can use [qiniu image styles](https://qiniu.kf5.com/hc/kb/article/68884/) instead [version](https://github.com/carrierwaveuploader/carrierwave#adding-versions) processing of CarrierWave.
 ```ruby
-# Case 1
+# Case 1: Array styles
+CarrierWave.configure do |config|
+  config.qiniu_styles = [:thumb, :large]
+end
+
 class AvatarUploader < CarrierWave::Uploader::Base
   storage :qiniu
 
-  qiniu_styles [:thumb, :large]
+  use_qiniu_styles
 end
 
 # original url
@@ -96,11 +100,9 @@ user.avatar.url(:thumb)
 # http://.../avatar.jpg-thumb
 
 
-# Case 2
-class AvatarUploader < CarrierWave::Uploader::Base
-  storage :qiniu
-
-  qiniu_styles thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800'
+# Case 2: Hash styles
+CarrierWave.configure do |config|
+  config.qiniu_styles = { thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800' }
 end
 
 # thumb url
@@ -113,6 +115,21 @@ user.avatar.url(:thumb, inline: true)
 
 # just style param
 user.avatar.url(style: 'imageView2/1/w/200')
+# http://.../avatar.jpg?imageView2/1/w/200
+
+# Case 3: Inline all styles in development environment
+CarrierWave.configure do |config|
+  config.qiniu_styles = { thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800' }
+  config.qiniu_style_inline = true if Rails.env.development?
+end
+
+class AvatarUploader < CarrierWave::Uploader::Base
+  storage :qiniu
+
+  use_qiniu_styles
+end
+
+user.avatar.url(:thumb)
 # http://.../avatar.jpg?imageView2/1/w/200
 ```
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,19 @@ end
 
 user.avatar.url(:thumb)
 # http://.../avatar.jpg?imageView2/1/w/200
+
+# Case 4: Custom styles and bucket
+class AvatarUploader < CarrierWave::Uploader::Base
+  storage :qiniu
+
+  # Override default styles and use your own
+  use_qiniu_styles :thumb => 'imageView/0/w/400', :xlarge => 'imageView/0/w/1600'
+  qiniu_bucket        = 'another_bucket'
+  qiniu_bucket_domain = 'another_domain'
+end
+
+user.avatar.url(:thumb, inline: true)
+# http://.../avatar.jpg?imageView2/1/w/400
 ```
 
 You can see a example project on: https://github.com/huobazi/carrierwave-qiniu-example

--- a/lib/carrierwave-qiniu.rb
+++ b/lib/carrierwave-qiniu.rb
@@ -4,6 +4,7 @@ require "carrierwave/storage/qiniu"
 require "carrierwave/qiniu/configuration"
 require "carrierwave/qiniu/style"
 require "carrierwave/uploader/base"
+ require "carrierwave/qiniu/railtie" if defined?(Rails)
 
 ::CarrierWave.configure do |config|
   config.storage_engines[:qiniu] = "::CarrierWave::Storage::Qiniu".freeze

--- a/lib/carrierwave/qiniu/configuration.rb
+++ b/lib/carrierwave/qiniu/configuration.rb
@@ -21,6 +21,8 @@ module CarrierWave
         add_config :qiniu_up_host
         add_config :qiniu_private_url_expires_in
         add_config :qiniu_style_separator
+        add_config :qiniu_style_inline
+        add_config :qiniu_styles
 
         alias_config :qiniu_protocal, :qiniu_protocol
 
@@ -41,6 +43,7 @@ module CarrierWave
             config.qiniu_callback_body = ''
             config.qiniu_persistent_notify_url = ''
             config.qiniu_style_separator = '-'
+            config.qiniu_style_inline = false
           end
         end
 

--- a/lib/carrierwave/qiniu/railtie.rb
+++ b/lib/carrierwave/qiniu/railtie.rb
@@ -1,0 +1,10 @@
+module CarrierWave
+  module Qiniu
+
+    class Railtie < Rails::Railtie
+      rake_tasks do
+        load 'carrierwave/tasks/qiniu.rake'
+      end
+    end
+  end
+end

--- a/lib/carrierwave/qiniu/style.rb
+++ b/lib/carrierwave/qiniu/style.rb
@@ -8,26 +8,40 @@ module CarrierWave
       class_methods do
         # === Examples:
         #
-        #    qiniu_styles [:thumbnail, :large]
-        #    qiniu_styles :thumbnail => 'imageView/0/w/200', :large => 'imageView/0/w/800'
-        #    qiniu_styles
+        #    CarrierWave.configure do |config|
+        #      config.qiniu_styles = [:thumbnail, :large]
+        #      # or
+        #      config.qiniu_styles = {:thumbnail => 'imageView/0/w/200', :large => 'imageView/0/w/800'}
+        #    end
         #
-        def qiniu_styles(versions = nil)
+        #    # Eanble qiniu styles otherwise default version processing
+        #    use_qiniu_styles
+        #
+        def use_qiniu_styles
+
           # Override #url method when set styles, otherwise still default strategy.
           unless include? ::CarrierWave::Qiniu::Url
             send(:include, ::CarrierWave::Qiniu::Url)
           end
 
-          @qiniu_styles = {}
-          if versions.is_a? Array
-            @qiniu_styles = versions.map { |version| [version.to_sym, nil] }.to_h
-          elsif versions.is_a? Hash
-            @qiniu_styles = versions.symbolize_keys
+          @_qiniu_styles = {}
+          if self.qiniu_styles
+            # Set default styles
+            @_qiniu_styles = parse_qiniu_styles(self.qiniu_styles)
           end
         end
 
         def get_qiniu_styles
-          @qiniu_styles
+          @_qiniu_styles
+        end
+
+        private
+        def parse_qiniu_styles(styles)
+          if styles.is_a? Array
+            styles.map { |version| [version.to_sym, nil] }.to_h
+          elsif styles.is_a? Hash
+            styles.symbolize_keys
+          end
         end
       end
     end

--- a/lib/carrierwave/qiniu/style.rb
+++ b/lib/carrierwave/qiniu/style.rb
@@ -15,9 +15,13 @@ module CarrierWave
         #    end
         #
         #    # Eanble qiniu styles otherwise default version processing
+        #    # And use default styles
         #    use_qiniu_styles
         #
-        def use_qiniu_styles
+        #    # Override default styles and use your own styles
+        #    use_qniu_styles :thumbnail => 'imageView/0/w/400', :xlarge => 'imageView/0/w/1600'
+        #
+        def use_qiniu_styles(versions = nil)
 
           # Override #url method when set styles, otherwise still default strategy.
           unless include? ::CarrierWave::Qiniu::Url
@@ -28,6 +32,10 @@ module CarrierWave
           if self.qiniu_styles
             # Set default styles
             @_qiniu_styles = parse_qiniu_styles(self.qiniu_styles)
+          elsif versions
+            # Set custom styles
+            self.qiniu_styles = versions
+            @_qiniu_styles = parse_qiniu_styles(versions)
           end
         end
 

--- a/lib/carrierwave/qiniu/url.rb
+++ b/lib/carrierwave/qiniu/url.rb
@@ -10,25 +10,31 @@ module CarrierWave
       def url(*args)
         return super if args.empty?
 
+        # Usage: avatar.url(style: 'imageView/0/w/200')
         if args.first.is_a? Hash
           options = args.first
-          # Usage: avatar.url(style: 'imageView/0/w/200')
           if options[:style]
             url = super({})
             return "#{url}?#{options[:style]}"
           end
         else
+        # Usage: avatar.url(version, options)
           version = args.first.to_sym
-          if qiniu_styles.key? version.to_sym
+          if styles.key? version.to_sym
             options = args.last
 
             # TODO: handle private url
             url = super({})
             # Usage: avatar.url(:version, inline: true)
-            if options.present? && options.is_a?(Hash) && options[:inline] && qiniu_styles[version]
-              return "#{url}?#{qiniu_styles[version]}"
+            if options.present? && options.is_a?(Hash) && options[:inline] && styles[version]
+              return "#{url}?#{styles[version]}"
             else # Usage: avatar.url(:version)
-              return "#{url}#{self.class.qiniu_style_separator}#{version}"
+              # inline mode
+              if self.class.qiniu_style_inline && styles[version]
+                return "#{url}?#{styles[version]}"
+              else
+                return "#{url}#{self.class.qiniu_style_separator}#{version}"
+              end
             end
           end
         end
@@ -37,7 +43,7 @@ module CarrierWave
         super
       end
 
-      def qiniu_styles
+      def styles
         self.class.get_qiniu_styles
       end
     end

--- a/lib/carrierwave/tasks/qiniu.rake
+++ b/lib/carrierwave/tasks/qiniu.rake
@@ -1,0 +1,21 @@
+namespace :carrierwave do
+  namespace :qiniu do
+    desc 'Sync Qiniu styles of uploader'
+    task sync_styles: :environment do
+      options = [:qiniu_access_key, :qiniu_secret_key, :qiniu_block_size, :qiniu_up_host].reduce({}) do |options, key|
+        options.merge!(key => CarrierWave::Uploader::Base.public_send(key))
+      end
+      # Config Qiniu establish_connection
+      CarrierWave::Storage::Qiniu::Connection.new(options)
+
+      bucket = CarrierWave::Uploader::Base.qiniu_bucket
+      styles = CarrierWave::Uploader::Base.qiniu_styles
+      if styles && styles.is_a?(Hash)
+        styles.each do |name, style|
+          puts "Bucket: #{bucket}, Set style: #{name} => #{style}"
+          Qiniu.set_style(bucket, name.to_s, style)
+        end
+      end
+    end
+  end
+end

--- a/spec/upload_spec.rb
+++ b/spec/upload_spec.rb
@@ -155,53 +155,52 @@ require 'carrierwave/processing/mini_magick'
   end
 
   context "Styles" do
+    class StylesUploader < CarrierWave::Uploader::Base
+      use_qiniu_styles
+    end
+
+    class StyledPhoto < ActiveRecord::Base
+      self.table_name = 'photos'
+
+      mount_uploader :image, StylesUploader
+    end
+
+    let(:photo) {
+      f = load_file("mm.jpg")
+      photo = StyledPhoto.new(image: f)
+      photo.save
+      photo
+    }
 
     context 'array styles' do
-      class ArrayStylesUploader < CarrierWave::Uploader::Base
-        qiniu_styles [:thumb]
-
-        def store_dir
-          "carrierwave-qiniu-spec"
-        end
-      end
-
-      class ArrayStyledPhoto < ActiveRecord::Base
-        self.table_name = 'photos'
-
-        mount_uploader :image, ArrayStylesUploader
-      end
-
       it 'style url' do
-        f = load_file("mm.jpg")
-        photo = ArrayStyledPhoto.new(image: f)
-        photo.save
+        StylesUploader.qiniu_styles = [:thumb]
+        StylesUploader.use_qiniu_styles
+
         photo.errors.count.should == 0
 
         expect(photo.image.url).not_to be_nil
         puts photo.image.url('thumb')
         expect(photo.image.url('thumb').end_with?("mm.jpg-thumb")).to eq true
       end
+
+      it 'global inline mode' do
+        StylesUploader.qiniu_styles = [:thumb]
+        StylesUploader.use_qiniu_styles
+        CarrierWave.configure {|config| config.qiniu_style_inline = true }
+
+        expect(photo.image.url('thumb', inline: true).end_with?("mm.jpg-thumb")).to eq true
+        CarrierWave.configure {|config| config.qiniu_style_inline = false }
+      end
     end
 
     context "Hash styles" do
-      class HashStylesUploader < CarrierWave::Uploader::Base
-        qiniu_styles thumb: "imageView2/0/w/200"
-
-        def store_dir
-          "carrierwave-qiniu-spec"
-        end
-      end
-
-      class HashStyledPhoto < ActiveRecord::Base
-        self.table_name = 'photos'
-
-        mount_uploader :image, HashStylesUploader
+      before :each do
+        StylesUploader.qiniu_styles = { thumb: 'imageView2/0/w/200' }
+        StylesUploader.use_qiniu_styles
       end
 
       it 'style url' do
-        f = load_file("mm.jpg")
-        photo = HashStyledPhoto.new(image: f)
-        photo.save
         photo.errors.count.should == 0
 
         expect(photo.image.url).not_to be_nil
@@ -210,29 +209,19 @@ require 'carrierwave/processing/mini_magick'
       end
 
       it 'inline style url' do
-        f = load_file("mm.jpg")
-        photo = HashStyledPhoto.new(image: f)
-        photo.save
         puts photo.image.url('thumb', inline: true)
         expect(photo.image.url('thumb', inline: true).end_with?("mm.jpg?imageView2/0/w/200")).to eq true
+      end
+
+      it 'global inline mode' do
+        CarrierWave.configure {|config| config.qiniu_style_inline = true }
+        expect(photo.image.url('thumb', inline: true).end_with?("mm.jpg?imageView2/0/w/200")).to eq true
+        CarrierWave.configure {|config| config.qiniu_style_inline = false }
       end
     end
 
     context "Only Style param" do
-      class StylesUploader < CarrierWave::Uploader::Base
-        qiniu_styles
-      end
-
-      class StyledPhoto < ActiveRecord::Base
-        self.table_name = 'photos'
-
-        mount_uploader :image, StylesUploader
-      end
-
       it 'url' do
-        f = load_file("mm.jpg")
-        photo = StyledPhoto.new(image: f)
-        photo.save
         puts photo.image.url(style: 'imageView2/0/w/200')
         expect(photo.image.url(style: 'imageView2/0/w/200').end_with?("mm.jpg?imageView2/0/w/200")).to eq true
       end


### PR DESCRIPTION
### 调整了图片样式配置改为全局配置

之前 #68  直接在 uploader 上配置图片样式的方式有些弊端。因为七牛的图片样式是基于 bucket 的，一个bucket 一套图片样式，在 uploader 上配置图片样式可能会导致重复和不一致。比如下面。

```ruby
class AvatarUploader
  qiniu_styles  thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800' 
end

class ImageUploader
  # thumb 不一致， large 重复
  qiniu_styles  thumb: 'imageView2/1/w/400', large: 'imageView2/1/w/800' 
end
```

这次将图片样式通过全局配置，就可以解决上面问题。同时 url 方法和之前行为一致没有变化。

```ruby
CarrierWave.configure do |config|
  config.qiniu_styles = { thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800' }
  config.qiniu_style_inline = true if Rails.env.development?
end

class AvatarUploader
  use_qiniu_styles
end
```

### 添加全局内联模式

同时还提供了全局内联模式，方便开发环境调试。
```ruby
CarrierWave.configure do |config|
  config.qiniu_styles = { thumb: 'imageView2/1/w/200', large: 'imageView2/1/w/800' }
  config.qiniu_style_inline = true if Rails.env.development?
end

user.avatar.url(:thumb)
# http://.../avatar.jpg?imageView2/1/w/200
```

### 添加同步图片样式到七牛的 Rake 任务

```
rake carrierwave:qiniu:sync_styles
# Bucket: bastengao, Set style: thumb => imageView2/1/w/200
# Bucket: bastengao, Set style: large => imageView2/1/w/800
```