### PR TITLE
Require carrierwave ~> 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ example: https://github.com/huobazi/carrierwave-qiniu-example
 
 ## Installation
 
-Add this line to your application's Gemfile:
+Add the following to your application's Gemfile:
 
     gem 'carrierwave-qiniu', '~> 1.0.1'
+    # If you need to use locales other than English
+    gem 'carrierwave-i18n'
 
 And then execute:
 

--- a/carrierwave-qiniu.gemspec
+++ b/carrierwave-qiniu.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
   gem.version       = Carrierwave::Qiniu::VERSION
 
 
-  gem.add_dependency "carrierwave" , "~> 0"
+  gem.add_dependency "carrierwave" , "~> 1.0"
   gem.add_dependency "qiniu", "~> 6.8", ">= 6.8.0"
 end


### PR DESCRIPTION
Carrierwave 1.0 came with some [breaking changes](https://github.com/carrierwaveuploader/carrierwave/blob/master/CHANGELOG.md) on 2016-12-24, but carrierwave-qiniu doesn't need any change.

Please release a new version as soon as possible. I think that increasing one minor version up (that is, 1.1) should be enough.