### PR TITLE
url 为空时, url(style: xxx)会生成错误的 url

### DIFF
--- a/lib/carrierwave/qiniu/url.rb
+++ b/lib/carrierwave/qiniu/url.rb
@@ -11,10 +11,12 @@ module CarrierWave
         return super if args.empty?
 
         # Usage: avatar.url(style: 'imageView/0/w/200')
+        url = super({})
+        return unless url
+
         if args.first.is_a? Hash
           options = args.first
           if options[:style]
-            url = super({})
             return "#{url}?#{options[:style]}"
           end
         else
@@ -24,7 +26,6 @@ module CarrierWave
             options = args.last
 
             # TODO: handle private url
-            url = super({})
             # Usage: avatar.url(:version, inline: true)
             if options.present? && options.is_a?(Hash) && options[:inline] && styles[version]
               return "#{url}?#{styles[version]}"


### PR DESCRIPTION
如`post.cover_image.url(style: 'imageView2/2/w/420')`这样使用时
如果`post.cover_image.url`为空, 那么应该直接返回 nil. 而不是`?imageView2/2/w/420`

这样就会造成一些错误请求
比如 search 页面的某些结果没有图片. 参数会被认为是相对路径
浏览器会发出`https://www.jiqizhixin.com/search?imageView2/2/w/420`这样的请求