### PR TITLE
解决未定义的 qiniu_delete_after_days 和 qiniu_persistent_pipeline 方法错误

### DIFF
--- a/lib/carrierwave/qiniu/configuration.rb
+++ b/lib/carrierwave/qiniu/configuration.rb
@@ -23,6 +23,8 @@ module CarrierWave
         add_config :qiniu_style_separator
         add_config :qiniu_style_inline
         add_config :qiniu_styles
+        add_config :qiniu_persistent_pipeline
+        add_config :qiniu_delete_after_days
 
         alias_config :qiniu_protocal, :qiniu_protocol
 


### PR DESCRIPTION
最新的 1.1.4 版，上传文件会提示 uploader 未定义的 qiniu_delete_after_days 和 qiniu_persistent_pipeline 方法错误。